### PR TITLE
Flag code fixes

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -1,17 +1,20 @@
 class Challenge < ActiveRecord::Base
   
   belongs_to :category
-
-  has_many :flags, :dependent => :destroy
   
+  has_many :flags, :dependent => :destroy, inverse_of: :challenge
+
   validates :name, :point_value, :flags, :category_id, :state, presence: true
+
+  accepts_nested_attributes_for :flags, :allow_destroy => true
+
   validates :state, inclusion: %w( open closed force_closed )
 
   # Handles the ordering of all returned challenge objects.
   default_scope -> { order(:point_value, :name) }
   
   attr_accessor :submitted_flag
-  
+
   def state_enum
     ['open', 'closed', 'force_closed']
   end

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -1,5 +1,5 @@
 class Flag < ActiveRecord::Base
-  belongs_to :challenge
+  belongs_to :challenge, inverse_of: :flags
 
   has_many :solved_challenges
 

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -13,6 +13,8 @@ class Player < User
   geocoded_by :city
   after_validation :geocode, :if => :city_changed?
 
+  #touch file in /opt/keys
+  after_create :touch_file
 
   def score
     points = 0
@@ -23,6 +25,27 @@ class Player < User
       points = points + a.point_value
     end
     points
+  end
+
+  def display_name
+    if self.eligible
+      return read_attribute(:display_name)
+    else
+      return read_attribute(:display_name) + " (ineligible)"
+    end
+  end
+
+  # Grab the first 10 characters from the email and append the users ID.
+  # Since we have 2 different scoreboards the ID is not sufficient, therefore
+  # if we seed it with some additional data it should solve the issue.
+  def key_file_name
+    self.email.tr('^A-Za-z', '')[0..10] + self.id.to_s
+  end
+
+  private
+  
+  def touch_file
+    `touch /opt/keys/#{self.key_file_name}` 
   end
   
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,27 +9,9 @@ class User < ActiveRecord::Base
   validates :email, :type, presence: true
   validates :type, inclusion: %w( Admin Player )
   
-  #touch file in /opt/keys
-  after_create :touch_file
-  
   # is admin
   def admin?
     self.is_a?(Admin)
-  end
-
-  def display_name
-    if self.eligible
-      return read_attribute(:display_name)
-    else
-      return read_attribute(:display_name) + " (ineligible)"
-    end
-  end
-
-  # Grab the first 10 characters from the email and append the users ID.
-  # Since we have 2 different scoreboards the ID is not sufficient, therefore
-  # if we seed it with some additional data it should solve the issue.
-  def key_file_name
-    self.email.tr('^A-Za-z', '')[0..10] + self.id.to_s
   end
 
   def set_password; nil; end
@@ -38,13 +20,6 @@ class User < ActiveRecord::Base
     return nil if value.blank?
     self.password = value
     self.password_confirmation = value
-  end
-  
-  
-  private
-  
-  def touch_file
-    `touch /opt/keys/#{self.key_file_name}` 
   end
   
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -90,7 +90,7 @@ RailsAdmin.config do |config|
   end
 
   config.model Flag do
-    modal do
+    nested do
       fields :flag, :api_request, :video_url
     end
   end


### PR DESCRIPTION
The flag code was left in a rather fragile state before the last CTF due to modifications made to allow for multiple flags on each challenge. These changes should fix the code to not allow for some of the issues encountered last time.

This also strips the code for VPN certificates out of the main user model and places it in the player model in order to avoid VPN certificates being generated for admins since they don't need them.