### PR TITLE
Forcing a challenge closed provide more meaningful colors

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -19,8 +19,13 @@ class Challenge < ActiveRecord::Base
     ['open', 'closed', 'force_closed']
   end
   
+  # This bypasses game open check and only looks at the challenge state
+  def challenge_open?
+    self.state == "open"
+  end  
+  
   def open?
-    (self.state == "open" && self.category.game.open?)
+    (self.challenge_open? && self.category.game.open?)
   end
   
   def is_solved?

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -32,6 +32,10 @@ class Challenge < ActiveRecord::Base
     self.state.eql? "closed"
   end
 
+  def force_closed?
+    self.state.eql? "force_closed"
+  end
+
   def get_current_solved_challenge(user)
     solved_challenge = SolvedChallenge.where("challenge_id = :challenge and user_id = :user", challenge: self, user: user)
     solved_challenge.first unless solved_challenge.nil?

--- a/app/views/challenges/index.html.haml
+++ b/app/views/challenges/index.html.haml
@@ -22,12 +22,16 @@
                 - is_solved = challenge.is_solved?
               - else
                 - is_solved = challenge.is_solved_by_user?(current_user)
-              - if is_solved
+              - if challenge.force_closed? && challenge.is_solved?
+                - style << "color:DarkOrange;"              
+              - elsif challenge.force_closed?
+                - style << "color:red;"
+              - elsif is_solved
                 - style << "color:#08C;"
-              - elsif challenge.open?
+              - elsif challenge.open? || (is_admin && challenge.challenge_open?)
                 - style << "color:green;"
               - else
-                - style << "color:red;"
+                - style << "color:gray;"                
               %td{ style: style }= link_to_if (is_admin || challenge.open?), challenge.point_value, challenge, style: "color:inherit;"
             - else
               %td &nbsp;


### PR DESCRIPTION
…ed challenges

I think that we need to make sure that this fix is what we want.

1) The original issue states that admins can get into any challenge they want and the colors do not change. That's probably ok. 

2) The second comment seems to refer to the color of force closed challenges seen by players/teams that have already solved the challenge. Does a player care or does it matter if a challenge a player has already completed is closed?

