### PR TITLE
Add Message email handler for enqueing mass email jobs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/email_messages_job.rb
+++ b/app/jobs/email_messages_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Sends the specified message to every user in the database.
+class EmailMessagesJob < ApplicationJob
+  queue_as :default
+
+  def perform(message)
+    User.all.find_each do |usr|
+      UserMailer.message_notification(usr, message).deliver_later
+    end
+  end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -10,8 +10,6 @@ class Message < ApplicationRecord
   private
 
   def send_email
-    User.all.find_each do |usr|
-      UserMailer.message_notification(usr, self).deliver_later
-    end
+    EmailMessagesJob.perform_later(self)
   end
 end

--- a/test/jobs/email_messages_job_test.rb
+++ b/test/jobs/email_messages_job_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class EmailMessagesJobTest < ActiveJob::TestCase
+  test "job properly enqueues emails for all users" do
+    message = messages(:message_one)
+    EmailMessagesJob.perform_now(message)
+    assert_enqueued_jobs User.count
+  end
+end


### PR DESCRIPTION
This fixes an issue we have had on heroku when sending mass messages. Since every enqueued email creates an entry in the database we run into an issue where we are entering a very large number of records into the database (1.4k currently) which causes Heroku to timeout. With this we can instead move that operation into a background worker which avoids freezing up the UI and also avoids users not getting their emails due to a timeout.

Closes #133
  