### PR TITLE
Add inivisible recaptcha to the signup and registration pages.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'prawn'
 gem 'rails', '~> 5.1.4'
 gem 'rails_admin'
 gem 'rails_email_validator'
+gem 'recaptcha', require: 'recaptcha/rails'
 gem 'sentry-raven'
 
 gem 'letter_opener', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,8 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    recaptcha (4.6.3)
+      json
     ref (2.0.0)
     remotipart (1.3.1)
     request_store (1.4.0)
@@ -346,6 +348,7 @@ DEPENDENCIES
   rails-controller-testing
   rails_admin
   rails_email_validator
+  recaptcha
   rubocop
   sass-rails
   scout_apm

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ MITRE CTF Scoreboard is a fully featured CTF platform with scoreboard and regist
 + Install ruby.
 + In your terminal run `gem install bundler`
 + Install postgres to your system (and create a role with your system username). This can be done on mac using Homebrew by running `brew install postgresql`.
++ Setup Recaptcha. This can be done by getting a site key from [here](https://www.google.com/recaptcha/intro/) and then setting the `RECAPTCHA_SITE_KEY` and `RECAPTCHA_SECRET_KEY` environment variables for the application. The steps for this will vary based on your hosting platform.
 + Run `bundle install`
 + Run `bundle exec rake db:create`
 + Run `bundle exec rake db:schema:load`
@@ -27,7 +28,7 @@ MITRE CTF Scoreboard is a fully featured CTF platform with scoreboard and regist
 
 Automated emails can be setup by adding
 `min hour * * * /bin/bash -l -c 'cd /path/to/ctf-scoreboard && RAILS_ENV=production bundle exec rake email:automated_email --silent'`
-where `min`, `hour`, and `path/to/ctf-scoreboard` are replaced with the values you prefer. 
+where `min`, `hour`, and `path/to/ctf-scoreboard` are replaced with the values you prefer.
 If the project is being hosted on Heroku a daily task can be created using the Heroku Scheduler to run `rake email:automated_email`
 
 ### Screenshots ###

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -42,7 +42,7 @@ class ChallengesController < ApplicationController
   end
 
   def find_solved_by
-    @solved_by = @challenge.solved_challenges.includes(team: :division).order(created_at: :desc)
+    @solved_by = @challenge.solved_challenges.includes(team: :division).order(created_at: :asc)
   end
 
   def find_and_log_flag

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,6 +3,17 @@
 class RegistrationsController < Devise::RegistrationsController
   before_action :load_game, :load_message_count
 
+  def create
+    if verify_recaptcha
+      super
+    else
+      build_resource(sign_up_params)
+      clean_up_passwords(resource)
+      set_flash_message! :alert, :recaptcha_failed
+      render :new
+    end
+  end
+
   # DELETE /resource
   def destroy
     if resource.team_captain?

--- a/app/views/challenges/show.html.haml
+++ b/app/views/challenges/show.html.haml
@@ -26,7 +26,7 @@
       .controls
         = f.text_field :submitted_flag, :class => "span5"
     .control-group
-      = button_tag "Submit", :class => "btn btn-primary"
+      = invisible_recaptcha_tags text: 'Submit', :class => "btn btn-primary"
 
 - if @solved_by.length > 0
   %table.table.table-bordered.table-striped

--- a/app/views/users/registrations/_user_form.html.haml
+++ b/app/views/users/registrations/_user_form.html.haml
@@ -70,7 +70,7 @@
         .controls
           = f.password_field :current_password, :class => "textarea"
   .controls
-    = button_tag :Submit, :label => 'Confirm Account', :class => "btn"
+    = invisible_recaptcha_tags text: 'Submit', :class => "btn"
 - if on_update_page
   %hr
   = form_for(resource, as: resource_name, url: registration_path(resource_name), :html => { :multipart => "true", :class => "form-horizontal"}, :method => :delete) do |f|

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,3 +1,16 @@
 Geocoder.configure(
   timeout: 15
 )
+
+if Rails.env.test?
+  Geocoder.configure(:lookup => :test)
+
+  Geocoder::Lookup::Test.set_default_stub(
+    [
+      {
+        'country'      => 'United States',
+        'country_code' => 'US'
+      }
+    ]
+  )
+end

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,4 +1,4 @@
 Recaptcha.configure do |config|
-  config.site_key  = ENV['RECAPTCHA_SITE_KEY'] ||  '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
+  config.site_key   = ENV['RECAPTCHA_SITE_KEY'] ||  '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
   config.secret_key = ENV['RECAPTCHA_SECRET_KEY'] || '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'
 end

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,4 @@
+Recaptcha.configure do |config|
+  config.site_key  = ENV['RECAPTCHA_SITE_KEY'] ||  '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
+  config.secret_key = ENV['RECAPTCHA_SECRET_KEY'] || '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -44,6 +44,7 @@ en:
       destroyed: 'Bye! Your account was successfully cancelled. We hope to see you again soon.'
       captain_tried_to_destroy: 'Team captains must promote a team member to team captain before deleting their account.'
       password_needed_destroy: 'You need to provide your current password to delete your account.'
+      recaptcha_failed: 'Potential bot activity detected. Please ensure that Javascript is enabled in your browser and try again.'
     unlocks:
       send_instructions: 'You will receive an email with instructions about how to unlock your account in a few minutes.'
       unlocked: 'Your account has been unlocked successfully. Please sign in to continue.'


### PR DESCRIPTION
Last year we had at least 1 case of a user attempting to brute-force the scoreboard. This should prevent such a thing from happening again. Closes #134

Todo before merging: Add ENV vars for production mode to Heroku.