### PR TITLE
Fix issue with certificates being generated too early

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
     @pending_requests = current_user.user_requests.pending
     (@filterrific = initialize_filterrific(
       Team, params[:filterrific],
-      select_options: { location: us_states, division: Division.all.map { |d| [d.name, d.id] } }
+      select_options: { location: state_enum, division: Division.all.map { |d| [d.name, d.id] } }
     )) || return
     @teams = @filterrific.find.includes(:division).page(params[:page])
 

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module UserHelper
-  def years_in_school
+  # All methods named appropriately to work with rails_admin select
+
+  def year_in_school_enum
     [
       %w[9 9], %w[10 10], %w[11 11], %w[12 12],
       ['College - Freshman', '13'],
@@ -13,7 +15,7 @@ module UserHelper
   end
 
   # rubocop:disable Metrics/MethodLength
-  def us_states
+  def state_enum
     [
       %w[Alabama AL],
       %w[Alaska AK],
@@ -71,7 +73,7 @@ module UserHelper
     ]
   end
 
-  def genders
+  def gender_enum
     [
       %w[Male Male],
       %w[Female Female]

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -21,14 +21,15 @@ class UserMailer < ApplicationMailer
   end
 
   # Assumes user is on a team
-  def ranking(user, rank, path)
+  def ranking(user, rank = nil)
     @user = user
     @team = @user.team
     @div = user.team.division
     rank = 1 + (@div.ordered_teams.index @team) if rank.nil?
     @rank = rank
+    attachment = @user.generate_certificate(rank)
 
-    attachments['Competition Certificate.pdf'] = File.read(path) unless path.nil?
+    attachments['Competition Certificate.pdf'] = attachment.read unless attachment.nil?
 
     mail(to: @user.email, subject: 'MITRE CTF: Congratulations!')
   end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -44,16 +44,6 @@ class Game < ApplicationRecord
     end
   end
 
-  # hit all divisions and iterate over all teams to create certs
-  def generate_completion_certs(send_email = true)
-    divisions.each do |div|
-      size = div.teams.size
-      div.ordered_teams.each_with_index do |team, index|
-        team.generate_completion_certificates index + 1, size, send_email unless team.users.size.zero?
-      end
-    end
-  end
-
   # generates the top of the certificate when given a Prawn Document
   def generate_certificate_header(doc)
     doc.font('Helvetica', size: 28, style: :bold) do

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -147,6 +147,18 @@ class Team < ApplicationRecord
     update_eligibility
   end
 
+  # generates the body of the email certificate
+  def generate_certificate_body(doc, user_full_name, rank)
+    doc.bounding_box([55, 200], width: 640, height: 200) do
+      doc.font('Helvetica-Bold', size: 18) do
+        doc.text(I18n.t('users.team_completion_cert_string',
+                        full_name: user_full_name, team_name: team_name,
+                        score: score, rank: rank, team_size: division.teams.size),
+                 color: '005BA1', align: :center, leading: 4)
+      end
+    end
+  end
+
   private
 
   # If a team doesn't have a team captain but does have a user, set the team captain to the first user.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,8 @@ class User < ApplicationRecord
 
   after_create :create_vpn_cert_request
 
+  scope :interested_in_employment, -> { where(interested_in_employment: true) }
+
   reverse_geocoded_by :latitude, :longitude do |obj, results|
     if (geo = results.first)
       obj.country = geo.country

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -163,23 +163,8 @@ class User < ApplicationRecord
       doc.bounding_box([55, 450], width: 640, height: 200) do
         Game.instance.generate_certificate_header doc
       end
-      generate_certificate_body doc, rank
+      team.generate_certificate_body doc, full_name, rank
     end
-  end
-
-  # generates the body of the certificate
-  def generate_certificate_body(doc, rank)
-    doc.bounding_box([55, 200], width: 640, height: 200) do
-      doc.font('Helvetica-Bold', size: 18) do
-        doc.text team_completion_cert_string(rank), color: '005BA1', align: :center, leading: 4
-      end
-    end
-  end
-
-  def team_completion_cert_string(rank)
-    "This is to certify that #{full_name}
-     successfully competed as a member of Team #{team.team_name},
-     achieving #{team.score} points and finishing #{rank} out of #{team.division.teams.size} teams."
   end
 
   # If a user chooses to compete for prizes then they must be located in the US and be in school.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,19 +132,6 @@ class User < ApplicationRecord
     team&.update_captain_and_eligibility
   end
 
-  # For Rails Admin Select
-  def gender_enum
-    %w[Male Female]
-  end
-
-  def state_enum
-    us_states
-  end
-
-  def year_in_school_enum
-    years_in_school
-  end
-
   # generate cert for specific user
   def generate_certificate(rank)
     return nil unless on_a_team?

--- a/app/views/user_mailer/ranking.html.haml
+++ b/app/views/user_mailer/ranking.html.haml
@@ -19,7 +19,7 @@
   %p
     #{link_to 'I am seeking a full-time cyber security position.', 'http://f.rfer.us/MITREvG.1q2'}
   %p
-    Also, please take the time to make sure your #{link_to 'resume is uploaded', edit_user_registration_url} during this step.
+    Also, please take the time to make sure your #{link_to 'resume is uploaded', edit_user_registration_url} and email #{mail_to 'ctf@mitre.org'} stating you have applied during this step for our internal tracking purposes.
   %p
     While this competition was open to professional and government participants as part of cyber training, only
     eligible teams composed of high school and college students will be considered for winning prizes, scholarships and

--- a/app/views/users/registrations/_user_form.html.haml
+++ b/app/views/users/registrations/_user_form.html.haml
@@ -28,12 +28,12 @@
   .control-group
     = f.label :year_in_school, :class => "control-label-required"
     .controls
-      = f.select :year_in_school, options_for_select(years_in_school, resource.year_in_school), { :include_blank => '' }, :onChange => "hidePrizesCheckbox()"
+      = f.select :year_in_school, options_for_select(year_in_school_enum, resource.year_in_school), { :include_blank => '' }, :onChange => "hidePrizesCheckbox()"
   .control-group
     .helpertext-wrapper{ 'data-toggle' => 'tooltip', 'data-placement' => 'right', :title => "Enter the state in which you are a resident." }
       = f.label :state, :class => "control-label-required"
       .controls
-        = f.select :state, options_for_select(us_states, resource.state), { :include_blank => '' }, :onChange => "hidePrizesCheckbox()"
+        = f.select :state, options_for_select(state_enum, resource.state), { :include_blank => '' }, :onChange => "hidePrizesCheckbox()"
   .control-group
     = f.label :password, :class => on_update_page ? "control-label" : "control-label-required"
     .controls
@@ -56,7 +56,7 @@
     .helpertext-wrapper{  'data-toggle' => 'tooltip', 'data-placement' => 'right', :title => "Gender will be used in aggregate statistics and are held confidentially." }
       = f.label :gender, :class => "control-label"
       .controls
-        = f.select :gender, options_for_select(genders, resource.gender), { :include_blank => '' }
+        = f.select :gender, options_for_select(gender_enum, resource.gender), { :include_blank => '' }
   .control-group
     .helpertext-wrapper{  'data-toggle' => 'tooltip', 'data-placement' => 'right', :title => "Age will be used in aggregate statistics and are held confidentially." }
       = f.label :age, :class => "control-label"

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -40,6 +40,18 @@ RailsAdmin.config do |config|
     end
   end
 
+  config.model 'User' do
+    # Have to disable filtering on this since it is an integer and it
+    # breaks search
+    configure :year_in_school do
+      searchable false
+    end
+
+    list do
+      scopes [nil, :interested_in_employment]
+    end
+  end
+
   # If you want to track changes on your models:
   # config.audit_with :history, 'User'
 

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -24,14 +24,6 @@ RailsAdmin.config do |config|
         end
       end
     end
-
-    edit do
-      [:start, :stop].each do |f|
-        configure f do
-          help "Required - Must be in UTC. Current time is #{Time.now.utc}"
-        end
-      end
-    end
   end
 
   config.model 'Message' do

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -24,6 +24,14 @@ RailsAdmin.config do |config|
         end
       end
     end
+
+    edit do
+      [:start, :stop].each do |f|
+        configure f do
+          help "Required - Must be in UTC."
+        end
+      end
+    end
   end
 
   config.model 'Message' do

--- a/config/locales/registration.en.yml
+++ b/config/locales/registration.en.yml
@@ -74,5 +74,8 @@ en:
     login_required: 'You must login in order to perform this action.'
     certificate_not_ready: 'Your VPN Certificate is not yet ready for download, please try again in a few minutes.'
     download_not_available: 'The download you have selected is not available for this user.'
+    team_completion_cert_string: "This is to certify that %{full_name}
+     successfully competed as a member of Team %{team_name},
+     achieving %{score} points and finishing %{rank} out of %{team_size} teams."
   admin:
     should_not_do_action: 'Admins should use the Rails Admin console to perform administrative actions.'

--- a/lib/cert_module.rb
+++ b/lib/cert_module.rb
@@ -20,10 +20,5 @@ module CertModule
     def fallback_fonts
       %w[TwitterColorEmoji SourceHanSans]
     end
-
-    # def self.generate(options = {}, &block)
-    #
-    #   super(template, options, &block)
-    # end
   end
 end

--- a/lib/cert_module.rb
+++ b/lib/cert_module.rb
@@ -4,6 +4,8 @@ module CertModule
   class CompletionPdf < Prawn::Document
     def initialize(options)
       set_fallback_fonts
+      options[:background] ||= Rails.root.join 'templates', 'ctf-certificate-template.jpg'
+      options[:margin] ||= 0
       super(options)
     end
 
@@ -18,5 +20,10 @@ module CertModule
     def fallback_fonts
       %w[TwitterColorEmoji SourceHanSans]
     end
+
+    # def self.generate(options = {}, &block)
+    #
+    #   super(template, options, &block)
+    # end
   end
 end

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -8,7 +8,15 @@ namespace :email do
 
   desc 'Send completion email to all users on teams'
   task completion_email: :environment do
-    Game.instance.generate_completion_certs
+    Division.all.each do |div|
+      div.ordered_teams.each_with_index do |team, index|
+        next if team.score.zero?
+
+        team.users.each do |user|
+          UserMailer.ranking(user, index + 1).deliver_later
+        end
+      end
+    end
   end
 
   desc 'Send challenge open source notification email to all users'

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -12,7 +12,6 @@ class UserMailerTest < ActionMailer::TestCase
   def setup
     # Is there a sane way to check to see if the URL provided is right without
     # typing the whole email in HTML?
-    Game.instance.generate_completion_certs false
     @inv_email_body = strip_tags("Hello #{user_invites(:invite_one).email}! You have been
                    invited to join the team #{user_invites(:invite_one).team.team_name}
                    for the upcoming MITRE CTF Click the link below to register
@@ -76,8 +75,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   test 'ranking no employment' do
     user = users(:user_one)
-    email = UserMailer.ranking(user, 1 + (divisions(:high_school).ordered_teams.index users(:user_one).team),
-                               Rails.root.join( 'tmp', 'high_school-certificates', user.team.id.to_s, "#{user.id.to_s}.pdf")).deliver_now
+    email = UserMailer.ranking(user).deliver_now
 
     assert_not ActionMailer::Base.deliveries.empty?
 
@@ -92,8 +90,7 @@ class UserMailerTest < ActionMailer::TestCase
   test 'ranking with employment' do
     user = users(:user_one)
     user.update_attributes(interested_in_employment: true)
-    email = UserMailer.ranking(user, 1 + (divisions(:high_school).ordered_teams.index users(:user_one).team),
-                               Rails.root.join( 'tmp', 'high_school-certificates', user.team.id.to_s, "#{user.id.to_s}.pdf")).deliver_now
+    email = UserMailer.ranking(user).deliver_now
 
     assert_not ActionMailer::Base.deliveries.empty?
 
@@ -107,8 +104,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   test 'ranking email for first no employment' do
     user = users(:user_four)
-    email = UserMailer.ranking(user, 1 + (divisions(:professional).ordered_teams.index user.team),
-                               Rails.root.join( 'tmp', 'professional-certificates', user.team.id.to_s, "#{user.id.to_s}.pdf")).deliver_now
+    email = UserMailer.ranking(user).deliver_now
 
     assert_not ActionMailer::Base.deliveries.empty?
 
@@ -123,8 +119,7 @@ class UserMailerTest < ActionMailer::TestCase
   test 'ranking email for first employment' do
     user = users(:user_four)
     user.update_column(:interested_in_employment, true)
-    email = UserMailer.ranking(user, 1 + (divisions(:professional).ordered_teams.index user.team),
-                               Rails.root.join( 'tmp', 'professional-certificates', user.team.id.to_s, "#{user.id.to_s}.pdf")).deliver_now
+    email = UserMailer.ranking(user, 1 + (divisions(:professional).ordered_teams.index user.team)).deliver_now
 
     assert_not ActionMailer::Base.deliveries.empty?
 

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -33,24 +33,6 @@ class GameTest < ActiveSupport::TestCase
     assert_equal User.all.size, ActionMailer::Base.deliveries.size
   end
 
-  test 'send ranking emails' do
-    game = games(:mitre_ctf_game)
-    game.generate_completion_certs
-    assert_equal User.where.not(team_id: nil).size, ActionMailer::Base.deliveries.size
-  end
-
-  test 'generate all certs' do
-    game = Game.includes(teams: :users).instance
-    game.generate_completion_certs false
-    game.divisions.each do |division|
-      division.teams.each do |team|
-        team.users.each do |user|
-          assert_equal true, (File.exist? (Rails.root.join 'tmp', Division.transform(division.name) + '-certificates', team.id.to_s, user.id.to_s + '.pdf'))
-        end
-      end
-    end
-  end
-
   test 'send open source emails' do
     game = games(:mitre_ctf_game)
     game.open_source


### PR DESCRIPTION
This code is less efficient than the previous code however it is the best we can do in Heroku. Since Heroku workers are restarted every 24 hours we are having an issue where we have so many teams that the emails can't finish sending before the worker is reset, losing all of the messages. This modifies the code to generate the email on the fly and send it right away, avoiding the issue of the file not being available.