### PR TITLE
Long fields should not cause the application display to break

### DIFF
--- a/app/assets/stylesheets/custom-bootstrap.css.scss
+++ b/app/assets/stylesheets/custom-bootstrap.css.scss
@@ -13,6 +13,19 @@ body { padding-top: 60px; }
   -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#0A2C641E, endColorstr=#0A2C641E)";
   background-color: rgba(10, 44, 100,0.3);
 }
+
+td.break-word {
+  max-width: 100px;
+  @extend .break-word;
+}
+
+.break-word {
+  line-height: normal;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .remove_top_padding {
   margin-top:-20px;
 }

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -95,7 +95,7 @@ class TeamsController < ApplicationController
   end
 
   def load_summary_info
-    @solved_challenges = @team&.solved_challenges
+    @solved_challenges = @team&.solved_challenges&.includes(challenge: :category)
     load_team_flag_stats
     @flags_per_hour = @team.submitted_flags.group_by_hour('submitted_flags.created_at', format: '%l:%M %p').count
     @team_flag_submissions = [

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -20,7 +20,7 @@ class Team < ApplicationRecord
   # team_captain has no inverse
   belongs_to :team_captain, class_name: 'User'
   accepts_nested_attributes_for :user_invites
-  validates :team_name, :affiliation, presence: true, obscenity: true
+  validates :team_name, :affiliation, presence: true, length: { maximum: 255 }, obscenity: true
   validates :team_name, uniqueness: { case_sensitive: false }
 
   after_save :update_captain_and_eligibility

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,7 +54,7 @@ class User < ApplicationRecord
     after_create :link_to_invitations
     after_update :update_team
     validates :email, uniqueness: true
-    validates :full_name, :affiliation, presence: true, obscenity: true
+    validates :full_name, :affiliation, presence: true, length: { maximum: 255 }, obscenity: true
     validates :state, presence: true
     validates :age, numericality: { greater_than_or_equal_to: 0, less_than: 200 }, allow_blank: true
     validates :year_in_school, inclusion: { in: [0, 9, 10, 11, 12, 13, 14, 15, 16] }, presence: true

--- a/app/views/achievements/index.html.haml
+++ b/app/views/achievements/index.html.haml
@@ -13,5 +13,5 @@
       - @achievements.each do |a|
         %tr
           %td= a.text
-          %td= link_to a.team.display_name, summary_team_path(a.team)
+          %td.break-word= link_to a.team.display_name, summary_team_path(a.team)
           %td= a.created_at.strftime("%b %e %y, %R %Z")

--- a/app/views/games/_team_list.html.haml
+++ b/app/views/games/_team_list.html.haml
@@ -21,7 +21,7 @@
       - percent = score.to_f / max.to_f * 100.0
         %tr
           %td= i + 1
-          %td= link_to t.display_name, summary_team_path(t)
+          %td.break-word= link_to t.display_name, summary_team_path(t)
           %td= t.achievements.size
           %td= score
           %td

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -37,7 +37,7 @@
               - if user_signed_in?
                 %li.dropdown
                   %a.dropdown-toggle{"data-toggle" => "dropdown", :href => "#"}
-                    Hello #{current_user.full_name}
+                    Hello #{truncate(current_user.full_name, length: 30)}
                     %b.caret
                   %ul.dropdown-menu
                     %li

--- a/app/views/teams/_team_form.html.haml
+++ b/app/views/teams/_team_form.html.haml
@@ -12,11 +12,11 @@
   .control-group
     = f.label :team_name, :class => "control-label"
     .controls
-      = f.text_field :team_name, :class => "textarea"
+      = f.text_field :team_name, :class => "textarea", maxlength: 255
   .control-group
     = f.label :affiliation, :class => "control-label"
     .controls
-      = f.text_field :affiliation, :class => "textarea"
+      = f.text_field :affiliation, :class => "textarea", maxlength: 255
   .control-group
     = f.label :division, :class => "control-label"
     .controls

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -3,8 +3,8 @@
 - content_for :vpn_cert_download do
   - if current_user&.vpn_cert_available?
     = render partial: "users/vpn_cert_alert"
-%h2 #{@team.display_name} - Team Information
-%h3 Affiliation: #{@team.affiliation}
+%h2.break-word= @team.display_name
+%h3.break-word Affiliation: #{@team.affiliation}
 %table.table.table-condensed.table-striped
   %thead
   %tr
@@ -50,7 +50,7 @@
   .span6
     %h4 Team Division Status
     You have currently selected the
-    %b=@team.division.name
+    %b= @team.division.name
     division for your team.
     - if @team.appropriate_division_level?
       This division is acceptable for your team.

--- a/app/views/teams/summary.html.haml
+++ b/app/views/teams/summary.html.haml
@@ -1,5 +1,5 @@
 - content_for :header do
-  #{@team.display_name}
+  .break-word= @team.display_name
 
 - content_for :subheading do
   #{@team.division.name} - #{pluralize(@solved_challenges.size, 'solved challenge')}

--- a/app/views/users/registrations/_user_form.html.haml
+++ b/app/views/users/registrations/_user_form.html.haml
@@ -15,7 +15,7 @@
   .control-group
     = f.label :full_name, :class => "control-label-required"
     .controls
-      = f.text_field :full_name, :class => "textarea"
+      = f.text_field :full_name, :class => "textarea", maxlength: 255
   .control-group
     = f.label :email, :class => "control-label-required"
     .controls


### PR DESCRIPTION
This commit hides long team names from showing up in the application. Also, team names are now limited to 255 characters