### PR TITLE
Add markdown export to the scoreboard for admins

### DIFF
--- a/app/views/games/show.markdown.haml
+++ b/app/views/games/show.markdown.haml
@@ -1,0 +1,19 @@
+= @game.name
+= '=' * @game.name.length
+
+- @categories.each do |category|
+  = "\n\#\#\# #{category.name}\n"
+  %table
+    %tr
+      %th Title
+      %th Value
+      %th Repository
+      %th Description
+    - category.challenges.each do |challenge|
+      %tr
+        %td= challenge.name
+        %td= challenge.point_value
+        %td
+          %a{:href => "https://\<URL\>/\<YEAR\>-#{category.name}-#{challenge.point_value}"}
+            = "\<YEAR\>-#{category.name}-#{challenge.point_value}"
+        %td= challenge.description

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,5 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+
+Mime::Type.register "text/markdown", :markdown

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -56,11 +56,28 @@ class GamesControllerTest < ActionController::TestCase
     end
   end
 
+  test 'guest and user cannot access show as markdown' do
+    assert_raises(ActiveRecord::RecordNotFound) do
+      get :show, format: :markdown # Nobody is signed in
+    end
+    sign_in users(:user_four)
+    assert_raises(ActiveRecord::RecordNotFound) do
+      get :show, format: :markdown # User is signed in
+    end
+  end
+
   test 'admin can access transcript' do
     user = add_resume_transcript_to(users(:user_four))
     sign_in users(:admin_user)
     get :transcripts
     assert_response :success
     assert_equal "application/zip", response.content_type
+  end
+
+  test 'admin can access show as markdown' do
+    sign_in users(:admin_user)
+    get :show, format: :markdown
+    assert_response :success
+    assert_equal "text/markdown", response.content_type
   end
 end


### PR DESCRIPTION
In order to open source the challenges we need to be able to generate a markdown version of the scoreboard for GitHub. This makes that task easier by letting all admins navigate to `game.markdown`.