### PR TITLE
Add summary pie chart, cleanup other pie chart code

### DIFF
--- a/app/views/teams/_team_summary.html.haml
+++ b/app/views/teams/_team_summary.html.haml
@@ -1,6 +1,8 @@
-- if @flags_per_hour.count > 1
-  %h3.muted Team Flag Submissions
+%h3.muted Team Flag Submissions
+- if @solved_challenges.count > 0
   = line_chart @team_flag_submissions, colors: ['#b8d12f', '#00abca']
+- else
+  .zero-items-text Nothing to Report
 %hr
 %div.row
   %div.span5
@@ -23,24 +25,32 @@
               %td= s.challenge.point_value
               %td= s.created_at.strftime("%b %e %y, %R %Z")
   %div.span7
-    %h3.muted Per User Statistics
+    %h3.muted Solved Challenge Categories
     - if @solved_challenges.size == 0
-      .zero-items-text Nothing to Report
+      .zero-items-text No Solved Challenges
     - else
-      = column_chart @per_user_stats, legend: 'bottom', xtitle: "User ID", stacked: true, colors: ['#b8d12f', '#00abca']
-      - if current_user&.admin?
-        %br/
-        %div.span7
-          %table.table.table-bordered.table-striped
-            %thead
-              %tr
-                %th User ID
-                %th Name
-                %th Email
-            %tbody
-              - @team.users.each do |user|
-                %tr
-                  %td=link_to user.id, rails_admin.show_path("user", user)
-                  %td= user.full_name
-                  %td= user.email
+      = pie_chart @flag_categories
+- if current_user&.admin?
+  %hr
+  %div.row
+    %div.span5
+      %h3.muted Team Members
+      %table.table.table-bordered.table-striped
+        %thead
+          %tr
+            %th User ID
+            %th Name
+            %th Email
+        %tbody
+          - @team.users.each do |user|
+            %tr
+              %td=link_to user.id, rails_admin.show_path("user", user)
+              %td= user.full_name
+              %td= user.email
+    %div.span7
+      %h3.muted Per User Statistics
+      - if @solved_challenges.size == 0
+        .zero-items-text Nothing to Report
+      - else
+        = column_chart @per_user_stats, legend: 'bottom', xtitle: "User ID", stacked: true, colors: ['#b8d12f', '#00abca']
 %br

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -86,8 +86,9 @@ class TeamsControllerTest < ActionController::TestCase
     sign_in user
     get :summary, params: { id: teams(:team_two) }
     assert_response :success
-    assert_select 'h3', 'Per User Statistics'
+    assert_select 'h3', 'Team Flag Submissions'
     assert_select 'h3', 'Solved Challenges'
+    assert_select 'h3', 'Solved Challenge Categories'
   end
 
   test 'team summary page correctly redirects if the team does not exist' do
@@ -256,13 +257,29 @@ class TeamsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'summary after game is closed' do
+  test 'summary is available after game is closed' do
     games(:mitre_ctf_game).update_attributes(start: Time.now - 9.hours, stop: Time.now - 1.hours)
     user = users(:user_two)
     sign_in user
     get :summary, params: { id: teams(:team_two) }
     assert_response :success
-    assert_select 'h3', 'Per User Statistics'
+    assert_select 'h3', 'Team Flag Submissions'
     assert_select 'h3', 'Solved Challenges'
+    assert_select 'h3', 'Solved Challenge Categories'
+    assert_select 'h3', {count: 0, text: 'Team Members'}, 'Team member list should only be visible to administrators'
+    assert_select 'h3', {count: 0, text: 'Per User Statistics'}, 'Per User Statistics should only be visible to administrators'
+  end
+
+  test 'summary page shows additional information to administrators' do
+    games(:mitre_ctf_game).update_attributes(start: Time.now - 9.hours, stop: Time.now - 1.hours)
+    user = users(:admin_user)
+    sign_in user
+    get :summary, params: { id: teams(:team_two) }
+    assert_response :success
+    assert_select 'h3', 'Team Flag Submissions'
+    assert_select 'h3', 'Solved Challenges'
+    assert_select 'h3', 'Solved Challenge Categories'
+    assert_select 'h3', 'Team Members'
+    assert_select 'h3', 'Per User Statistics'
   end
 end


### PR DESCRIPTION
This adds a pie chart of what categories users have solved challenges in, and hides the per-user bar chart for everyone except admins.

Closes #222