### PR TITLE
Add coveralls config

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+---
+service_name: travis-pro


### PR DESCRIPTION
This is apparently necessary to get Coveralls to recognize that we are on travis-ci.com

We aren't actually using travis pro, however since we are in the travis-ci.com beta this is necessary.