### PR TITLE
Fix crash on previewing challenge with no category

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -54,8 +54,7 @@ class Challenge < ApplicationRecord
   end
 
   def category_list
-    return t('challenges.no_category') if categories.empty?
-
+    return I18n.t('challenges.no_category') if categories.empty?
     categories.map(&:name).join(', ')
   end
 


### PR DESCRIPTION
The program didn't call the right function when displaying a challenge with no category. This fixes that.