### PR TITLE
End team score calculations when the game ends

### DIFF
--- a/app/lib/flag_challenge_share_module.rb
+++ b/app/lib/flag_challenge_share_module.rb
@@ -82,11 +82,11 @@ module FlagChallengeShareModule
   private
 
   def calc_points_for_first_solve
-    first_capture_point_bonus + calc_point_value(start_calculation_at, Time.now.utc)
+    first_capture_point_bonus + calc_point_value(start_calculation_at, Game.instance.defense_end)
   end
 
   def calc_points_for_solve
-    potential_shares = calc_shares(first_solve_time, Time.now.utc)
+    potential_shares = calc_shares(first_solve_time, Game.instance.defense_end)
     convert_shares_to_points_for(
       potential_shares,
       calc_offensive_shares_for_solved_challenges.values.sum + potential_shares,

--- a/test/models/pentest_flag_test.rb
+++ b/test/models/pentest_flag_test.rb
@@ -8,11 +8,11 @@ class DefenseFlagTest < ActiveSupport::TestCase
                   :pentest_challenge,
                   point_value: 100,
                   first_capture_point_bonus: 0,
-                  initial_shares: 1,
+                  initial_shares: 1000,
                   unsolved_increment_period: 1, # Hours
-                  unsolved_increment_points: 0,
+                  unsolved_increment_points: 2,
                   solved_decrement_period: 1, # Hours
-                  solved_decrement_shares: 0,
+                  solved_decrement_shares: 100,
                   defense_period: 1, # Hours
                   defense_points: 0,
                   flag_count: 0
@@ -26,6 +26,24 @@ class DefenseFlagTest < ActiveSupport::TestCase
     solved_challenge = create(:pentest_solved_challenge, team: solve_team, challenge: @challenge)
     point_value = solved_challenge.flag.display_point_value(unsolve_team)
     assert_equal 50, point_value
+  end
+
+  test 'point value stops increasing and decreasing after game completion' do
+    @game.update(start: 3.hours.ago, stop: 2.hours.ago)
+    unsolve_team = create(:team)
+    point_value = @challenge.defense_flags.sample.display_point_value(unsolve_team)
+    assert_equal 102, point_value
+  end
+
+  test 'point value stops increasing and decreasing after game completion for solved challenge' do
+    @game.update(start: 3.hours.ago, stop: 2.hours.ago)
+    solve_team = create(:team)
+    unsolve_team = create(:team)
+    solved_challenge = create(:pentest_solved_challenge, team: solve_team, challenge: @challenge, created_at: 3.hours.ago)
+    # Points decrease at ~3 points per hour with the challenge defined above
+    # This game only lasts 1 hour and therefore unsolve_team is shown they would've received
+    # 47 points if they solved this challenge right at the end of the game.
+    assert_equal 47, solved_challenge.flag.display_point_value(unsolve_team)
   end
 
   test 'challenge open?' do


### PR DESCRIPTION
Currently we were showing users up-to-date information on how many points they would receive even after the game ends. With this commit it stops calculation at defense_end instead.