### PR TITLE
Ensure that ScoreAdjustments and other FeedItems are only counted once

### DIFF
--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -72,20 +72,31 @@ class Division < ApplicationRecord
   # This does not calculate the score for PentestChallenges
   def calculate_standard_solved_challenge_score
     teams.includes(:achievements).joins(
-      "LEFT JOIN feed_items AS point_feed_items
-             ON point_feed_items.team_id = teams.id
-             AND point_feed_items.type IN ('StandardSolvedChallenge', 'ScoreAdjustment')
-             LEFT JOIN feed_items AS pentest_feed_items
-             ON pentest_feed_items.team_id = teams.id
-             AND pentest_feed_items.type IN ('PentestSolvedChallenge')
-             LEFT JOIN challenges ON challenges.id = point_feed_items.challenge_id
-             AND challenges.type IN ('StandardChallenge')"
+      "LEFT JOIN LATERAL
+          (
+            SELECT
+              COALESCE(sum(challenges.point_value), 0) + COALESCE(sum(feed_items.point_value), 0) as team_score,
+              MAX(feed_items.created_at) as last_solve_time
+            FROM feed_items
+            LEFT JOIN challenges
+              ON challenges.id = feed_items.challenge_id
+              AND challenges.type IN ('StandardChallenge')
+            WHERE feed_items.team_id = teams.id
+            AND feed_items.type IN ('StandardSolvedChallenge', 'ScoreAdjustment')
+          ) AS point_feed_items ON true
+          LEFT JOIN LATERAL
+          (
+            SELECT MAX(feed_items.created_at) as last_solve_time
+            FROM feed_items
+            WHERE feed_items.team_id = teams.id
+            AND feed_items.type IN ('PentestSolvedChallenge')
+          ) AS pentest_feed_items ON true"
     )
          .group('teams.id')
          .select(
-           'COALESCE(sum(challenges.point_value), 0) + COALESCE(sum(point_feed_items.point_value), 0)
-             as team_score,
-           GREATEST(MAX(pentest_feed_items.created_at), MAX(point_feed_items.created_at)) as last_solve_time, teams.*'
+           'COALESCE(sum(point_feed_items.team_score), 0) as team_score,
+            GREATEST(MAX(pentest_feed_items.last_solve_time), MAX(point_feed_items.last_solve_time)) as last_solve_time,
+            teams.*'
          )
          .index_with(&:team_score)
   end

--- a/test/models/score_adjustment_test.rb
+++ b/test/models/score_adjustment_test.rb
@@ -4,7 +4,7 @@ class ScoreAdjustmentTest < ActiveSupport::TestCase
   include ActionView::Helpers::TextHelper
 
   def setup
-    create(:active_game)
+    @game = create(:active_game)
   end
 
   test 'point value is not zero' do
@@ -19,5 +19,19 @@ class ScoreAdjustmentTest < ActiveSupport::TestCase
     assert_equal solved_challenge.challenge.point_value, team_one.score
     score_adjustment = create(:score_adjustment, team: team_one, point_value: 100)
     assert_equal solved_challenge.challenge.point_value + score_adjustment.point_value, team_one.score
+  end
+
+  test 'score adjustment properly calculates when multiple PentestSolvedChallenges exist' do
+    scoring_team = create(:team)
+    offensive_team_1 = create(:team)
+    offensive_team_2 = create(:team)
+    # These are very basic PentestSolvedChallenges that basically act like regular StandardSolvedChallenges
+    # when only 1 team has solved them. That is why the point values can just be summed like they are below.
+    # This test is just to verify that the
+    create(:pentest_solved_challenge, team: scoring_team, point_value: 100, created_at: @game.start + 1.hour)
+    create(:pentest_solved_challenge, team: scoring_team, point_value: 100, created_at: @game.start + 1.hour)
+    assert_equal 200, scoring_team.score
+    score_adjustment = create(:score_adjustment, team: scoring_team, point_value: 100)
+    assert_equal 300, scoring_team.score
   end
 end


### PR DESCRIPTION
There is a strange bug happening for some teams on the ECTF scoreboard dump, where if you perform a ScoreAdjustment on them it happens multiple times. This ensures each teams score is only added once.

The double LEFT JOIN is the source of the problem, and it was due to a misunderstanding on my part of how the double LEFT JOIN was working.

Given the following (simplified) data:
<img width="400" alt="Screen Shot 2020-06-19 at 6 29 04 PM" src="https://user-images.githubusercontent.com/2308869/85183731-c2030500-b25a-11ea-9e7b-458e5a5571cd.png">
<img width="361" alt="Screen Shot 2020-06-19 at 6 29 18 PM" src="https://user-images.githubusercontent.com/2308869/85183736-caf3d680-b25a-11ea-83b6-fb099d946385.png">


I was thinking of the LEFT JOIN as looking something like this:
<img width="489" alt="whatIthought" src="https://user-images.githubusercontent.com/2308869/85183706-a5ff6380-b25a-11ea-8791-dfee09e0ce81.png">

And the LEFT JOIN actually looked something like this:
<img width="401" alt="Screen Shot 2020-06-19 at 6 28 40 PM" src="https://user-images.githubusercontent.com/2308869/85183721-b44d7f80-b25a-11ea-9fcd-191018d1a353.png">

By doing LEFT JOIN LATERAL instead of a LEFT JOIN we have gotten closer to what I originally thought was going on, which fixes the problem.