### PR TITLE
Fix game caching

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -35,7 +35,7 @@ class Game < ApplicationRecord
   end
 
   def instance_is_singleton
-    singleton = Game.instance
+    singleton = Game.all.first
     errors.add(:base, I18n.t('game.too_many')) if self != singleton && !singleton.nil?
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store, { size: 64.megabytes, expires_in: 5.minutes }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
Explicitly set a 5 minute timeout for the memory cache in production.
Bypass cache when validating that the Game object is a singleton (this should allow the user to save a game and blow away the cache if the cache gets in a bad state)