### PR TITLE
Fixes Team Solved Challenges Num Column

### DIFF
--- a/app/views/teams/_solved_challenges_table.html.haml
+++ b/app/views/teams/_solved_challenges_table.html.haml
@@ -1,14 +1,12 @@
 %table.table.table-bordered.table-striped
   %thead
     %tr
-      %th #
       %th= t('teams.summary.solved_challenges_table.challenge_header')
       %th= t('teams.summary.solved_challenges_table.points_header')
       %th= t('teams.summary.solved_challenges_table.when_header')
   %tbody
     - @team.solved_challenges.each_with_index do |s, i|
       %tr
-        %td= i + 1
         %td= always_link_to_if_admin(s.challenge.open?, s.challenge.name, game_challenge_path(s.challenge))
         %td= solved_challenge_table_point_value(s, @team)
         %td= view_time_format(s.created_at)


### PR DESCRIPTION
**Fixes Team Solved Challenges Num Column in Issue #443:** Removes challenge number header and table cell from _solved_challenges_table.html.haml.