### PR TITLE
Add ending time to challenges

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -34,8 +34,16 @@ class Challenge < ApplicationRecord
     state.eql? 'open'
   end
 
+  def before_close?
+    unless challenge_end.nil?
+      time = Time.now.utc
+      return time < challenge_end
+    end
+    true
+  end
+
   def open?
-    challenge_open? && game.open?
+    challenge_open? && before_close? && game.open?
   end
 
   def display_point_value(_ = nil)

--- a/db/migrate/20200624162213_add_challenge_end_time.rb
+++ b/db/migrate/20200624162213_add_challenge_end_time.rb
@@ -1,5 +1,5 @@
 class AddChallengeEndTime < ActiveRecord::Migration[6.0]
   def change
-    add_column :games, :datetime, :datetime
+    add_column :challenges, :challenge_end, :datetime
   end
 end

--- a/db/migrate/20200624162213_add_challenge_end_time.rb
+++ b/db/migrate/20200624162213_add_challenge_end_time.rb
@@ -1,0 +1,5 @@
+class AddChallengeEndTime < ActiveRecord::Migration[6.0]
+  def change
+    add_column :games, :datetime, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_16_180339) do
+ActiveRecord::Schema.define(version: 2020_06_24_162213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,6 +121,7 @@ ActiveRecord::Schema.define(version: 2020_04_16_180339) do
     t.text "prizes_text"
     t.text "terms_and_conditions"
     t.integer "board_layout", default: 0, null: false
+    t.datetime "datetime"
   end
 
   create_table "messages", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2020_06_24_162213) do
     t.integer "solved_decrement_period", default: 1
     t.boolean "design_phase", default: false
     t.bigint "game_id"
+    t.datetime "challenge_end"
     t.index ["game_id"], name: "index_challenges_on_game_id"
   end
 
@@ -121,7 +122,6 @@ ActiveRecord::Schema.define(version: 2020_06_24_162213) do
     t.text "prizes_text"
     t.text "terms_and_conditions"
     t.integer "board_layout", default: 0, null: false
-    t.datetime "datetime"
   end
 
   create_table "messages", id: :serial, force: :cascade do |t|

--- a/test/models/challenge_test.rb
+++ b/test/models/challenge_test.rb
@@ -11,4 +11,11 @@ class ChallengeTest < ActiveSupport::TestCase
     assert_equal chal2, chal1.next_challenge
     assert_nil chal3.next_challenge
   end
+
+  test 'game is closed when its passed closing time' do
+    game = create(:active_game)
+    challenge = create(:standard_challenge, challenge_end: Time.current - 1.days)
+
+    assert_not challenge.before_close?
+  end
 end


### PR DESCRIPTION
This:
- Adds a ``challenge_end`` column to challenges
- Adds method ``before_close?`` to the challenge model to check if it's before closing time
- Modifies ``challenge.open?`` to call ``before_close?``
- Adds a test to make sure you can't access a challenge past it's due date.