### PR TITLE
Add Team locations

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -91,6 +91,7 @@ class TeamsController < ApplicationController
       :affiliation,
       :division_id,
       :looking_for_members,
+      :team_location,
       user_invites_attributes: [:email]
     )
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -30,6 +30,7 @@ class Team < ApplicationRecord
   belongs_to :team_captain, class_name: 'User'
   accepts_nested_attributes_for :user_invites
   validates :team_name, :affiliation, presence: true, length: { maximum: 255 }, obscenity: true
+  validates :team_location, presence: true, if: -> { Game.instance.location_required? }, obscenity: true
   validates :team_name, uniqueness: { case_sensitive: false }
 
   after_save :refresh_team_info

--- a/app/views/teams/_team_form.html.haml
+++ b/app/views/teams/_team_form.html.haml
@@ -15,6 +15,11 @@
       = f.label :division, :class => "control-label-required"
       .controls
         = f.collection_select :division_id, @divisions, :id, :name, {}, {:class => 'form-control'}
+    - if @game.request_team_location
+      .form-group
+        = f.label :team_location, :class => @game.location_required ? "control-label-required" : "control-label"
+        .controls
+          = f.text_field :team_location, :class => "form-control textarea", maxlength: 255
     .form-group
       = f.label :looking_for_members, :class => "control-label-required", "data-placement" => "top", "data-toggle" => "tooltip", :title => I18n.t('teams.edit.looking_for_members_tooltip')
       .controls

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -61,12 +61,31 @@ RailsAdmin.config do |config|
           hide
         end
       end
-
       [:start, :stop].each do |f|
         configure f do
           help "Required - Must be in UTC."
         end
       end
+      field :title
+      field :start
+      field :stop
+      field :description
+      field :board_layout
+      field :team_size
+      field :organization
+      field :contact_email
+      field :prizes_available
+      field :prizes_text
+      field :enable_completion_certificates
+      field :completion_certificate_template
+      field :recruitment_text
+      field :open_source_url
+      field :request_team_location
+      field :location_required
+      field :contact_url
+      field :footer
+      field :terms_of_service
+      field :terms_and_conditions
     end
   end
 

--- a/db/migrate/20200626181022_add_locations_to_teams.rb
+++ b/db/migrate/20200626181022_add_locations_to_teams.rb
@@ -1,0 +1,7 @@
+class AddLocationsToTeams < ActiveRecord::Migration[6.0]
+  def change
+    add_column :games, :request_team_location, :boolean, default: false, null: false
+    add_column :games, :location_required, :boolean, default: false, null: false
+    add_column :teams, :team_location, :string, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -136,6 +136,8 @@ ActiveRecord::Schema.define(version: 2020_07_27_151127) do
     t.text "terms_and_conditions"
     t.integer "board_layout", default: 0, null: false
     t.boolean "registration_enabled", default: true, null: false
+    t.boolean "request_team_location", default: false, null: false
+    t.boolean "location_required", default: false, null: false
   end
 
   create_table "messages", id: :serial, force: :cascade do |t|
@@ -198,6 +200,7 @@ ActiveRecord::Schema.define(version: 2020_07_27_151127) do
     t.boolean "eligible", default: false
     t.integer "slots_available", default: 0
     t.boolean "looking_for_members", default: true, null: false
+    t.string "team_location", default: ""
     t.index "lower((team_name)::text)", name: "index_teams_on_team_name_unique", unique: true
     t.index ["division_id"], name: "index_teams_on_division_id"
     t.index ["team_captain_id"], name: "index_teams_on_team_captain_id"

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -351,6 +351,14 @@ class TeamsControllerTest < ActionController::TestCase
     assert_select 'h3', 'Per User Statistics'
   end
 
+  test 'edit a teams location' do
+    user = create(:user_with_team) 
+    sign_in user 
+    patch :update, params: { team: {team_location: 'location' }, id: user.team } 
+    assert_redirected_to team_path(user.team) 
+    assert 'location', user.team.team_location
+  end
+
   test 'summary pentest game' do
     Game.first.destroy
     create(:active_game)

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -135,4 +135,16 @@ class TeamTest < ActiveSupport::TestCase
     assert_equal challenge.point_value, team.score
   end
 
+  test 'cannot create team if location_required is true but no location is given' do
+    @game = create(:active_game, location_required: true)
+    assert_raises(ActiveRecord::RecordInvalid) {
+      team = create(:team)
+      assert_contains team.errors, "Team location can't be blank"
+    }
+  end
+
+  test 'create team with location' do
+    team = create(:team, team_location: 'earth')
+    assert_equal team.team_location, 'earth'
+  end
 end


### PR DESCRIPTION
Closes #370 
This makes it so teams can add their location (such as a classroom inside a school).