### PR TITLE
Integration Tests (new)

### DIFF
--- a/app/views/games/_team_list.html.haml
+++ b/app/views/games/_team_list.html.haml
@@ -1,5 +1,5 @@
 - if teams.nil? or teams.size.eql? 0
-  .zero-items-text= t('teams.summary.zero_teams_text')
+  %h4.zero-items-text= t('teams.summary.zero_teams_text')
 - else
   - max = 0
   %table.table.table-bordered.table-striped

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -6,15 +6,15 @@
 
 %table.table.table-condensed.table-striped
   %thead
-  %tr
-    %th.span1= t('teams.team_users_table.team_leader_header')
-    %th= t('teams.team_users_table.email_header')
-    %th= t('teams.team_users_table.grade')
-    %th.span2= t('teams.team_users_table.prize_eligibility_header')
-    %th= t('teams.team_users_table.remove_user_header')
-    - if @team_captain
-      %th
-        = t('teams.team_users_table.change_captian_header')
+    %tr
+      %th.span1= t('teams.users_table.team_leader_header')
+      %th= t('teams.users_table.email_header')
+      %th= t('teams.users_table.grade_header')
+      %th.span2= t('teams.users_table.prize_eligibility_header')
+      %th= t('teams.users_table.remove_user_header')
+      - if @team_captain
+        %th
+          = t('teams.users_table.change_captian_header')
   - @team.users.each do |current|
     %tbody
       %tr{ :class=>'success' }
@@ -25,9 +25,9 @@
         %td=current.division
         %td
           -if current.compete_for_prizes
-            = t('teams.show.team_users_table.compete_for_prizes_true')
+            = t('teams.users_table.compete_for_prizes_true')
           -else
-            = t('teams.show.team_users_table.compete_for_prizes_false')
+            = t('teams.users_table.compete_for_prizes_false')
         %td
           - if current_user.can_remove?(current)
             = link_to team_user_leave_team_path(current.team, current), method: :delete, data: { confirm: t('teams.show.remove_user_confirm') } do
@@ -41,8 +41,7 @@
 .row
   .span6
     %h4
-      = t('teams.show.team_eligibility_status_header')
-    = t('teams.show.label.team_prize_eligibility_status')
+      = t('teams.show.team_prize_eligibility_status')
     = t('teams.show.eligible_currently')
     - if @team.eligible?
       = t('teams.show.eligible_true')
@@ -51,7 +50,7 @@
       = t('teams.show.eligible_false')
   .span6
     %h4
-      = t('teams.show.label.team_division_status')
+      = t('teams.show.team_division_status')
     = t('teams.show.currently_selected_division', division: @team.division.name)
     - if @team.appropriate_division_level?
       = t('teams.show.division_true')

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -127,23 +127,6 @@ RailsAdmin.config do |config|
           "#{self.name}_field sponsorship_fields_toggler"
         end
       end
-      [
-        :challenge_categories,
-        :submitted_flags,
-        :solved_challenges,
-        :type
-      ].each do |field|
-        configure field do
-          hide
-        end
-      end
-    end
-    list do
-      field :name
-      field :description
-      field :categories
-      field :point_value
-      field :created_at
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,10 +43,6 @@ en:
       note: 'All fields are required.'
     new:
       header: 'Create a Team'
-      show:
-        label:
-          team_prize_eligibility_status: 'Team Prize Eligibility Status'
-          team_division_status: 'Team Division Status'
     invite:
       invite_requests_table:
         email_header: 'Email'
@@ -73,7 +69,7 @@ en:
     defensive_points_table:
       challenge_header: 'Challenge'
       points_header: 'Points'
-    team_users_table:
+    users_table:
       team_leader_header: 'Lead'
       email_header: 'Email'
       grade_header: 'School Level'
@@ -131,7 +127,8 @@ en:
       currently_selected_division: "You have currently selected %{division} for your team."
       division_true: 'This division is acceptable for your team.'
       division_false: "Your team is not eligible to compete in this division. Consider changing your team's division to match that of the most senior member of your team, or removing the member(s) causing your division to be incorrect."
-      team_eligibility_status_header: "Team Prize Eligibility Status"
+      team_prize_eligibility_status: "Team Prize Eligibility Status"
+      team_division_status: 'Team Division Status'
       eligible_currently: 'Your team is currently'
       eligible_true: 'competing for prizes. Your team will not be competing for prizes if any users on the team indicate they do not wish to compete for prizes, or the team is moved to an inappropriate division.'
       eligible_false: 'competing for prizes. One or more team members has indicated they do not want to compete for prizes. Please contact the users marked as ineligible above.'
@@ -320,6 +317,7 @@ en:
       messages: 'Messages'
       achievements: 'Achievements'
       summary: 'Summary'
+      contact: 'Contact'
       greeting: 'Hello, '
     game_name_if_organization_not_set: 'Gameboard'
     log_out: 'Log out'

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -39,7 +39,7 @@ class GamesControllerTest < ActionController::TestCase
       get :summary
 
       assert_response :success
-      assert_select "div.zero-items-text", {:count=>1, :text=>I18n.t('teams.summary.zero_teams_text')}, "Nothing to Report text is missing from Team Summary page"
+      assert_select "h4.zero-items-text", {:count=>1, :text=>I18n.t('teams.summary.zero_teams_text')}, "Nothing to Report text is missing from Team Summary page"
     end
   end
 

--- a/test/integration/achievement_display_modes_test.rb
+++ b/test/integration/achievement_display_modes_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class AchievementDisplayModesTest < ActionDispatch::IntegrationTest
+  include TeamsHelper
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @game = create(:active_game)
+  end
+
+  test 'achievement header shows on achievement page' do
+    sign_in create(:user)
+    get "/game/achievements"
+
+    assert_select 'h1', /Achievements/
+  end
+
+  test 'no achievement shows when there are no achievement' do
+    sign_in create(:user)
+    get "/game/achievements"
+    assert_select 'h4', /No achievements have been awarded/
+  end
+
+  test 'achievements display correctly' do
+    achievement = create(:achievement, team: create(:team), text: 'Example Achievement')
+    sign_in create(:user)
+    get "/game/achievements"
+    
+    assert_select 'table[class=table\ table-bordered\ table-striped]' do
+      assert_select 'thead' do
+        assert_select 'tr' do
+          assert_select 'th:nth-child(1)', I18n.t('achievements.index.table_header_achievement_name')
+          assert_select 'th:nth-child(2)', I18n.t('achievements.index.table_header_unlocked_by')
+          assert_select 'th:nth-child(3)', I18n.t('achievements.index.table_header_when')
+        end
+      end
+      assert_select 'tbody' do
+        assert_select 'tr:nth-child(1)' do
+          assert_select 'td:nth-child(1)', achievement.text
+          assert_select 'td:nth-child(2) a[href=\/teams\/' + achievement.team.id.to_s + '\/summary]'
+          assert_select 'td:nth-child(3)', achievement.created_at.strftime("%b %e %y, %R %Z")
+        end
+      end
+    end
+  end
+end

--- a/test/integration/application_display_modes_test.rb
+++ b/test/integration/application_display_modes_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class ApplicationDisplayModesTest < ActionDispatch::IntegrationTest
   include TeamsHelper
+  include Rails.application.routes.url_helpers
   include Devise::Test::IntegrationHelpers
 
   def setup
@@ -26,31 +27,31 @@ class ApplicationDisplayModesTest < ActionDispatch::IntegrationTest
     get "/"
     
     assert_select 'a[class=brand]', @game.organization, "Organization should show in navigation bar"
-    assert_select 'a[href=\/game]', I18n.t('application.navbar.challenges'), "Challenges should show in navigation bar"
-    assert_select 'a[href=\/game\/messages]', I18n.t('application.navbar.messages'), "Messages should show in navigation bar"
-    assert_select 'a[href=\/game\/achievements]', I18n.t('application.navbar.achievements'), "Achievements should show in navigation bar"
-    assert_select 'a[href=\/game\/summary]', I18n.t('application.navbar.summary'), "Summary should show in navigation bar"
+    assert_select "a[href=#{game_path.dump}]", I18n.t('application.navbar.challenges'), "Challenges should show in navigation bar"
+    assert_select "a[href=#{game_messages_path.dump}]", I18n.t('application.navbar.messages'), "Messages should show in navigation bar"
+    assert_select "a[href=#{game_achievements_path.dump}]", I18n.t('application.navbar.achievements'), "Achievements should show in navigation bar"
+    assert_select "a[href=#{game_summary_path.dump}]", I18n.t('application.navbar.summary'), "Summary should show in navigation bar"
     assert_select "a[href=#{@game.contact_url.dump}]", I18n.t('application.navbar.contact'), "Contact should show in navigation bar if contact_url is defined in game"
     
     assert_select 'a[class=dropdown-toggle]', I18n.t('home.index.login_or_register'), "Log in / Register should show in navigation bar while not signed in"
-    assert_select 'a[href=\/users\/login]', I18n.t('home.index.login'), "Login should show in navigation bar dropdown while not signed in"
-    assert_select 'a[href=\/users\/new]', I18n.t('home.index.register'), "Register should show in navigation bar dropdown while not signed in"
+    assert_select "a[href=#{new_user_session_path.dump}]", I18n.t('home.index.login'), "Login should show in navigation bar dropdown while not signed in"
+    assert_select "a[href=#{new_user_registration_path.dump}]", I18n.t('home.index.register'), "Register should show in navigation bar dropdown while not signed in"
   end
 
   test 'navigation bar shows all fields for logged in user' do
     sign_in create(:user)
     get "/"
 
-    assert_select 'a[href=\/users\/edit]', I18n.t('application.edit_account'), "Edit account should show in navigation bar dropdown while signed in"
-    assert_select 'a[href=\/users\/logout]', I18n.t('application.log_out'), "Log out should show in navigation bar dropdown while signed in"
+    assert_select "a[href=#{edit_user_registration_path.dump}]", I18n.t('application.edit_account'), "Edit account should show in navigation bar dropdown while signed in"
+    assert_select "a[href=#{destroy_user_session_path.dump}]", I18n.t('application.log_out'), "Log out should show in navigation bar dropdown while signed in"
   end
 
   test 'navigation bar shows all fields when logged in with no team' do
     sign_in create(:user)
     get "/"
 
-    assert_select 'a[href=\/users\/join_team]', I18n.t('home.index.join_team'), "Join team should show in navigation bar dropdown while signed in with no team"
-    assert_select 'a[href=\/teams\/new]', I18n.t('home.index.create_team'), "Create team should show in navigation bar dropdown while signed in with no team"
+    assert_select "a[href=#{join_team_users_path.dump}]", I18n.t('home.index.join_team'), "Join team should show in navigation bar dropdown while signed in with no team"
+    assert_select "a[href=#{new_team_path.dump}]", I18n.t('home.index.create_team'), "Create team should show in navigation bar dropdown while signed in with no team"
   end
 
   test 'navigation bar shows all fields when logged in with team' do
@@ -59,8 +60,8 @@ class ApplicationDisplayModesTest < ActionDispatch::IntegrationTest
     sign_in user
     get "/"
 
-    assert_select 'a[href=\/teams\/' + team.id.to_s + ']', I18n.t('home.index.view_team'), "View team should show in navigation bar dropdown while signed in with no team"
-    assert_select 'a[href=\/teams\/' + team.id.to_s + '\/edit]', I18n.t('home.index.edit_team'), "Edit team should show in navigation bar dropdown while signed in with no team"
+    assert_select "a[href=#{team_path(team.id).dump}]", I18n.t('home.index.view_team'), "View team should show in navigation bar dropdown while signed in with no team"
+    assert_select "a[href=#{edit_team_path(team.id).dump}]", I18n.t('home.index.edit_team'), "Edit team should show in navigation bar dropdown while signed in with no team"
   end
 
   test 'game name shows on home page' do

--- a/test/integration/application_display_modes_test.rb
+++ b/test/integration/application_display_modes_test.rb
@@ -1,0 +1,114 @@
+require 'test_helper'
+
+class ApplicationDisplayModesTest < ActionDispatch::IntegrationTest
+  include TeamsHelper
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @game = create(:game,
+      title: 'Example Game',
+      start: Time.now.utc - 5.days,
+      stop: Time.now.utc + 5.days,
+      description: 'Example Description',
+      terms_of_service: 'Example ToS',
+      terms_and_conditions: 'Example TAC',
+      organization: 'Example Organization',
+      contact_url: 'https://example.com',
+      footer: 'Example Footer',
+      team_size: 10,
+      contact_email: 'example@example.com',
+      open_source_url: 'https://github.com/mitre-cyber-academy/ctf-scoreboard',
+      board_layout: 0
+    )
+  end
+
+  test 'navigation bar shows all fields when logged out' do
+    get "/"
+    
+    assert_select 'a[class=brand]', @game.organization, "Organization should show in navigation bar"
+    assert_select 'a[href=\/game]', I18n.t('application.navbar.challenges'), "Challenges should show in navigation bar"
+    assert_select 'a[href=\/game\/messages]', I18n.t('application.navbar.messages'), "Messages should show in navigation bar"
+    assert_select 'a[href=\/game\/achievements]', I18n.t('application.navbar.achievements'), "Achievements should show in navigation bar"
+    assert_select 'a[href=\/game\/summary]', I18n.t('application.navbar.summary'), "Summary should show in navigation bar"
+    assert_select "a[href=#{@game.contact_url.dump}]", I18n.t('application.navbar.contact'), "Contact should show in navigation bar if contact_url is defined in game"
+    
+    assert_select 'a[class=dropdown-toggle]', I18n.t('home.index.login_or_register'), "Log in / Register should show in navigation bar while not signed in"
+    assert_select 'a[href=\/users\/login]', I18n.t('home.index.login'), "Login should show in navigation bar dropdown while not signed in"
+    assert_select 'a[href=\/users\/new]', I18n.t('home.index.register'), "Register should show in navigation bar dropdown while not signed in"
+  end
+
+  test 'navigation bar shows all fields for logged in user' do
+    sign_in create(:user)
+    get "/"
+
+    assert_select 'a[href=\/users\/edit]', I18n.t('application.edit_account'), "Edit account should show in navigation bar dropdown while signed in"
+    assert_select 'a[href=\/users\/logout]', I18n.t('application.log_out'), "Log out should show in navigation bar dropdown while signed in"
+  end
+
+  test 'navigation bar shows all fields when logged in with no team' do
+    sign_in create(:user)
+    get "/"
+
+    assert_select 'a[href=\/users\/join_team]', I18n.t('home.index.join_team'), "Join team should show in navigation bar dropdown while signed in with no team"
+    assert_select 'a[href=\/teams\/new]', I18n.t('home.index.create_team'), "Create team should show in navigation bar dropdown while signed in with no team"
+  end
+
+  test 'navigation bar shows all fields when logged in with team' do
+    team = create(:team, division: create(:hs_division))
+    user = team.team_captain
+    sign_in user
+    get "/"
+
+    assert_select 'a[href=\/teams\/' + team.id.to_s + ']', I18n.t('home.index.view_team'), "View team should show in navigation bar dropdown while signed in with no team"
+    assert_select 'a[href=\/teams\/' + team.id.to_s + '\/edit]', I18n.t('home.index.edit_team'), "Edit team should show in navigation bar dropdown while signed in with no team"
+  end
+
+  test 'game name shows on home page' do
+    get "/"
+
+    assert_select 'h1', /Example Game/
+  end
+
+  test 'correct catchphrase is displayed for active game' do
+    get "/"
+
+    assert_select 'h2', /Competition in Progress/
+  end
+
+  test 'game description is displayed correctly' do
+    get "/"
+
+    assert_select 'div[class=maincontent\ row-fluid\ indent-40px-left]' do
+      assert_select 'p', /Example Description/      
+    end
+  end
+
+  test 'register button shows on home page when not logged in' do
+    get "/"
+
+    assert_select 'a[class=btn\ btn-large\ btn-primary]', I18n.t('home.index.register')
+  end
+
+  test 'Join/Create team buttons show when viewing homepage' do
+    sign_in create(:user)
+    get "/"
+
+    assert_select 'a[class=btn\ btn-large\ btn-primary]', I18n.t('home.index.join_team')
+    assert_select 'a[class=btn\ btn-large\ btn-primary]', I18n.t('home.index.create_team')
+
+    team = create(:team, division: create(:hs_division))
+    user = team.team_captain
+    sign_in user
+    get "/"
+
+    assert_select 'a[class=btn\ btn-large\ btn-primary]', I18n.t('home.index.join_team')
+  end
+
+  test 'footer displays correctly' do
+  get "/"
+
+    assert_select 'footer[id=page-footer]' do
+      assert_select 'p', /Example Footer/
+    end
+  end
+end

--- a/test/integration/message_display_modes_test.rb
+++ b/test/integration/message_display_modes_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class MessageDisplayModesTest < ActionDispatch::IntegrationTest
+  include TeamsHelper
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @game = create(:active_game)
+  end
+
+  test 'messages header shows on messages page' do
+    sign_in create(:user)
+    get "/game/messages"
+
+    assert_select 'h1', /Messages/
+  end
+
+  test 'no messages shows when there are no messages' do
+    @game.messages.first.destroy
+    sign_in create(:user)
+    get "/game/messages"
+    assert_select 'h4', /No Messages/
+  end
+
+  test 'messages display contents correctly' do
+    message = create(:message, title: 'Example Title', text: 'Example Text')
+
+    get "/game/messages"
+    assert_select 'div[class=message]' do
+      assert_select 'h2', /Example Title/
+      assert_select 'p', /Example Text/
+    end
+  end
+end

--- a/test/integration/summary_display_modes_test.rb
+++ b/test/integration/summary_display_modes_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class SummaryDisplayModesTest < ActionDispatch::IntegrationTest
+  include TeamsHelper
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @game = create(:active_game)
+  end
+
+  test 'summary header shows on summary page' do
+    get "/game/summary"
+
+    assert_select 'h1', /Game Summary/
+  end
+
+  test 'no teams show when there are no teams' do
+    get "/game/summary"
+    assert_select 'h4', /No Teams/
+  end
+
+  test 'summary table displays correctly' do
+    team = create(:team)
+    sign_in create(:user)
+    get "/game/summary"
+    puts team.achievements 
+    assert_select 'table[class=table\ table-bordered\ table-striped]' do
+      assert_select 'thead' do
+        assert_select 'tr' do
+          assert_select 'th:nth-child(1)', '#'
+          assert_select 'th:nth-child(2)', I18n.t('game.team_list.team_name')
+          assert_select 'th:nth-child(3)', I18n.t('game.team_list.team_achievements')
+          assert_select 'th:nth-child(4)', I18n.t('game.team_list.team_points')
+        end
+      end
+      assert_select 'tbody' do
+        assert_select 'tr:nth-child(1)' do
+          assert_select 'td:nth-child(1)', '1'
+          assert_select 'td:nth-child(2) a[href=\/teams\/' + team.id.to_s + '\/summary]'
+          assert_select 'td:nth-child(3)', '0'
+          assert_select 'td:nth-child(4)', '0'
+        end
+      end
+    end
+  end
+end

--- a/test/integration/summary_display_modes_test.rb
+++ b/test/integration/summary_display_modes_test.rb
@@ -10,13 +10,10 @@ class SummaryDisplayModesTest < ActionDispatch::IntegrationTest
 
   test 'summary header shows on summary page' do
     get "/game/summary"
-
-    assert_select 'h1', /Game Summary/
-  end
-
-  test 'no teams show when there are no teams' do
-    get "/game/summary"
-    assert_select 'h4', /No Teams/
+    
+    Team.destroy_all
+    assert_select 'h1', /Game Summary/, 'Game summary header should show on the game summary page'
+    assert_select 'h4', /No Teams/, 'No teams should show when there are no teams on the game summary page'
   end
 
   test 'summary table displays correctly' do

--- a/test/integration/team_display_modes_test.rb
+++ b/test/integration/team_display_modes_test.rb
@@ -7,15 +7,8 @@ class TeamDisplayModesTest < ActionDispatch::IntegrationTest
   def setup
     @game = create(:active_game)
   end
-
-  test 'team creation header shows when visiting team creation page' do
-    sign_in create(:user)
-    get "/teams/new"
-
-    assert_select 'h1', /Create a Team/
-  end
-
-  test 'ensure that there is a form on the team creation page' do
+  
+  test 'team creation page' do
     sign_in create(:user)
     get "/teams/new"
 

--- a/test/integration/team_display_modes_test.rb
+++ b/test/integration/team_display_modes_test.rb
@@ -1,0 +1,134 @@
+require 'test_helper'
+
+class TeamDisplayModesTest < ActionDispatch::IntegrationTest
+  include TeamsHelper
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @game = create(:active_game)
+  end
+
+  test 'team creation header shows when visiting team creation page' do
+    sign_in create(:user)
+    get "/teams/new"
+
+    assert_select 'h1', /Create a Team/
+  end
+
+  test 'ensure that there is a form on the team creation page' do
+    sign_in create(:user)
+    get "/teams/new"
+
+    assert_select 'form[id=new_team]' do
+      assert_select 'label:nth-child(1)', 'Team name'
+      assert_select 'label:nth-child(1)', 'Affiliation'
+      assert_select 'label:nth-child(1)', 'Division'
+    end
+  end
+
+  test 'join team header shows when visiting team join page' do
+    sign_in create(:user)
+    get "/users/join_team"
+    assert_response :success
+    assert_select 'h1', /Join a Team/
+  end
+
+  test 'ensure the form is shown correctly on join team page' do
+    sign_in create(:user)
+    get "/users/join_team"
+
+    assert_select 'form[id=filterrific_filter]' do
+      assert_select 'div[class=row]' do
+        assert_select 'div:nth-child(1)', /Team Name/
+        assert_select 'div:nth-child(2)', /Affiliation/
+        assert_select 'div:nth-child(3)', /Location/
+        assert_select 'div:nth-child(4)', /Division/
+      end
+    end
+  end
+
+  test 'team page displays correctly' do
+    team = create(:team, team_name: 'Example Team', division: create(:division, name: 'Example Division'))
+    chal = create(:standard_challenge, point_value: 100, category_count: 2)
+    create(:standard_solved_challenge, challenge: chal, team: team)
+    user = team.team_captain
+    user.compete_for_prizes = false
+    sign_in user
+
+    get "/teams/#{team.id}"
+
+    assert_select 'h1', /Example Team/
+    assert_select 'h1', /ineligible/
+    assert_select 'h1', /100/
+
+    assert_select 'table[class=table\ table-condensed\ table-striped]' do
+      assert_select 'thead' do
+        assert_select 'tr' do
+          assert_select 'th:nth-child(1)', I18n.t('teams.users_table.team_leader_header')
+          assert_select 'th:nth-child(2)', I18n.t('teams.users_table.email_header')
+          assert_select 'th:nth-child(3)', I18n.t('teams.users_table.grade_header')
+          assert_select 'th:nth-child(4)', I18n.t('teams.users_table.prize_eligibility_header')
+          assert_select 'th:nth-child(5)', I18n.t('teams.users_table.remove_user_header')
+          assert_select 'th:nth-child(6)', I18n.t('teams.users_table.change_captian_header')
+        end
+      end
+      assert_select 'tbody' do
+        assert_select 'td:nth-child(1)' do
+          assert_select 'i'
+        end
+        assert_select 'td:nth-child(2)', team.team_captain.email
+        assert_select 'td:nth-child(4)', 'No'
+        assert_select 'td:nth-child(5)' do
+          assert_select 'i'
+        end
+        assert_select 'td:nth-child(6)'
+      end
+    end
+
+    assert_select 'body' do
+      assert_select 'div[class=container]' do
+        assert_select 'div:nth-child(1)' do
+          assert_select 'div:nth-child(1)' do
+            assert_select 'h4', I18n.t('teams.show.team_prize_eligibility_status')
+          end
+          assert_select 'div:nth-child(1)', /Your team is currently/
+          assert_select 'div:nth-child(1)', /NOT/
+          assert_select 'div:nth-child(1)', /competing for prizes/
+        end
+      end
+      assert_select 'div:nth-child(2)' do
+        assert_select 'h4', I18n.t('teams.show.team_division_status')
+      end
+      assert_select 'div:nth-child(2)', /Example Division/
+    end
+  end
+
+  test 'solved challenges show on team summary page' do
+    team = create(:team)
+    chal = create(:standard_challenge, point_value: 100, category_count: 2)
+    solve = create(:standard_solved_challenge, challenge: chal, team: team)
+    user = team.team_captain
+    sign_in user
+
+    get "/teams/#{team.id}/summary"
+
+    assert_select 'table[class=table\ table-bordered\ table-striped]' do
+      assert_select 'thead' do
+        assert_select 'tr' do
+          assert_select 'th:nth-child(1)', I18n.t('teams.summary.solved_challenges_table.challenge_header')
+          assert_select 'th:nth-child(2)', I18n.t('teams.summary.solved_challenges_table.points_header')
+          assert_select 'th:nth-child(3)', I18n.t('teams.summary.solved_challenges_table.when_header')
+        end
+      end
+      assert_select 'tbody' do
+        assert_select 'tr' do
+          assert_select 'td:nth-child(1)' do
+            assert_select 'a[href=\/game\/challenges\/' + chal.id.to_s + ']'
+          end
+          assert_select 'td:nth-child(2)', '100'
+          assert_select 'td:nth-child(3)', solve.created_at.strftime('%B %e at %l:%M %p %Z')
+        end
+      end
+    end
+  end
+end

--- a/test/integration/user_display_modes_test.rb
+++ b/test/integration/user_display_modes_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class UserDisplayModesTest < ActionDispatch::IntegrationTest
+  include TeamsHelper
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @game = create(:active_game)
+  end
+
+  test 'team creation header shows when visiting team creation page' do
+    sign_in create(:user)
+    get "/users/edit"
+
+    assert_select 'h1', /Edit Account/
+  end
+
+  test 'ensure that there is a form on the team creation page' do
+    sign_in create(:user)
+    get "/users/edit"
+
+    assert_select 'form[id=edit_user]' do
+      assert_select 'label', 'Full name'
+      assert_select 'label', 'Email'
+      assert_select 'label', 'Affiliation'
+      assert_select 'label', 'Year in school'
+      assert_select 'label', 'State'
+      assert_select 'label', 'Password'
+      assert_select 'label', 'Confirm Password'
+      assert_select 'label', 'Compete for prizes'
+      assert_select 'label', 'Interested in employment'
+      assert_select 'label', 'Age'
+      assert_select 'label', 'Major/Area of study'
+      assert_select 'label', 'Resume'
+      assert_select 'label', 'Unofficial transcript'
+      assert_select 'label', 'Current password'
+    end
+  end
+end


### PR DESCRIPTION
Closes #469 
Rebasing was creating a very large number of conflicts that would have taken much longer to deal with so I created a new branch off of upstream/master.
Adds tests for: 

- Application:
  - Navigation bar fields (Logged In + Logged Out)
  - Navigation bar fields (With Team + Without Team)
  - Game name shows on home page
  - Correct catchphrase is shown on home page
  - Game description is displayed on home page
  - Register button shows on home page when not logged in
  - Create/Join team shows up while logged in without a team
  - Join team shows up while logged in with a team (I think this should be changed to view team in a later commit)
  - Footer displays properly
 - Messages: 
   - Message header is visible
   - "No Messages" is show when there are no messages
   - Messages display contents correctly
 - Achievements: 
   - Achievement header shows
   - No achievements shows when there are no achievements
   - Achievement table displays correctly
 - Summary: 
   - Summary header shows
   - No teams shows when there are no teams
   - Summary table displays correctly
 - Team Pages:
   - Team creation:
      - Team creation header shows
      - Team creation form shows correctly
   - Join team:
      - Join team header shows
      - Join team table shows correctly
   - Team show/summary
      - Team show:
         - Team name + eligibility + points shows in header
         - Team user list table displays correctly
         - Team Prize Eligibility Status/Team Division Status displays correctly
      - Team summary:
          - Solve challenges table displays correctly