### PR TITLE
Fix viewing team page on rails admin

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -472,7 +472,7 @@ RailsAdmin.config do |config|
     list do
       field :team_name
       field :affiliation
-      field :team_captian
+      field :team_captain
       field :division
     end
   end


### PR DESCRIPTION
I had made a typo on the cleaning up rails admin PR that would cause the app to crash when viewing the teams page on the admin panel, this changes it from ``:team_captian`` to ``:team_captain``.