### PR TITLE
Flag Submission Box Disappears After Submitting Correct Flag-#530

### DIFF
--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -21,7 +21,6 @@ class ChallengesController < ApplicationController
       @solved_challenge = @flag_found.save_solved_challenge(current_user)
       @solved_video_url = @flag_found.video_url
       flash.now[:notice] = I18n.t('flag.accepted')
-      @solvable = false
     else
       flash.now[:alert] = wrong_flag_messages.sample
       @solvable = true

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -6,12 +6,11 @@ class ChallengesController < ApplicationController
   before_action :enforce_access
   before_action :load_game, :load_message_count
   before_action :find_challenge
-  before_action :find_solved_by, only: %i[show update]
+  before_action :find_solved_by, :check_solvable_by, only: %i[show update]
   before_action :valid_captcha, :find_and_log_flag, :on_team?, only: [:update]
 
   def show
     @solved_challenge = @challenge.get_solved_challenge_for(current_user.team)
-    @solvable = @challenge.can_be_solved_by(current_user.team)
     @solved_video_url = @solved_challenge.flag.video_url if @solved_challenge
     flash.now[:notice] = I18n.t('flag.accepted') if @solved_challenge
   end
@@ -20,12 +19,11 @@ class ChallengesController < ApplicationController
     if @flag_found
       @solved_challenge = @flag_found.save_solved_challenge(current_user)
       @solved_video_url = @flag_found.video_url
+      @solvable = false
       flash.now[:notice] = I18n.t('flag.accepted')
     else
       flash.now[:alert] = wrong_flag_messages.sample
-      @solvable = true
     end
-
     render :show
   end
 
@@ -45,6 +43,10 @@ class ChallengesController < ApplicationController
 
   def find_solved_by
     @solved_by = @challenge.solved_challenges.includes(team: :division).order(created_at: :asc)
+  end
+
+  def check_solvable_by
+    @solvable = @challenge.can_be_solved_by(current_user.team)
   end
 
   def find_and_log_flag

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -21,10 +21,11 @@ class ChallengesController < ApplicationController
       @solved_challenge = @flag_found.save_solved_challenge(current_user)
       @solved_video_url = @flag_found.video_url
       flash.now[:notice] = I18n.t('flag.accepted')
+      @solvable = false
     else
       flash.now[:alert] = wrong_flag_messages.sample
+      @solvable = true
     end
-    @solvable = @challenge.can_be_solved_by(current_user.team)
 
     render :show
   end

--- a/app/views/challenges/show.html.haml
+++ b/app/views/challenges/show.html.haml
@@ -1,5 +1,5 @@
 -# For PentestGames, @challenge here can actually be a flag object since Pentest challenges belong to teams + challenges and are linked by a flag object.
--# 
+-#
 - content_for :admin_menu do
   %a.dropdown-item{:href => admin_edit_url(@challenge)}= t('challenges.admin_edit_challenge', challengename: @challenge.name)
 

--- a/test/controllers/challenges_controller_test.rb
+++ b/test/controllers/challenges_controller_test.rb
@@ -83,6 +83,7 @@ class ChallengesControllerTest < ActionController::TestCase
       }
     end
     assert :success
+    assert_select 'input#challenge_submitted_flag', 1, 'Flag submission box should be visible with a bad submission'
     assert true, wrong_flag_messages.include?(flash[:notice])
   end
 
@@ -120,6 +121,7 @@ class ChallengesControllerTest < ActionController::TestCase
     flag_text = @pentest_challenge.defense_flags.find_by(team_id: @team2.id).flag
     put :update, params: { id: @pentest_challenge, team_id: @team2, challenge: { submitted_flag: flag_text } }
     assert_response :success
+    assert_select "input#challenge_submitted_flag", {count: 0}, 'Flag submission box should not be present when team has solved challenge'
     assert_equal I18n.t('flag.accepted'), flash[:notice]
   end
 
@@ -128,6 +130,7 @@ class ChallengesControllerTest < ActionController::TestCase
     sign_in @team1.team_captain
     get :show, params: { id: @pentest_challenge, team_id: @team2 }
     assert_response :success
+    assert_select "input#challenge_submitted_flag", {count: 0}, 'Flag submission box should not be present when team has solved challenge'
     assert_equal I18n.t('flag.accepted'), flash[:notice]
   end
 
@@ -136,6 +139,7 @@ class ChallengesControllerTest < ActionController::TestCase
     sign_in @team1.team_captain
     get :show, params: { id: @standard_challenge }
     assert_response :success
+    assert_select "input#challenge_submitted_flag", {count: 0}, 'Flag submission box should not be present when team has solved challenge'
     assert_equal I18n.t('flag.accepted'), flash[:notice]
   end
 
@@ -145,6 +149,7 @@ class ChallengesControllerTest < ActionController::TestCase
     sign_in @team1.team_captain
     get :show, params: { id: share_chal }
     assert_response :success
+    assert_select "input#challenge_submitted_flag", {count: 0}, 'Challenge flag submission box should not be present when team has solved challenge'
     assert_equal I18n.t('flag.accepted'), flash[:notice]
   end
 end


### PR DESCRIPTION
**Closes #530:** Allows the flag submission box to disappear after the user submits the correct flag for a challenge. Removes the use of the `can_be_solved_by(team)` method and instead directly passes a Boolean value to the view depending on whether the user solves the challenge. (**Side note:** Not using the `can_be_solved_by(team)` method saves a trip to the DB, slightly improving performance)