### PR TITLE
Specify ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
+ruby '~> 2.7.2'
+
 gem 'activerecord-precounter'
 gem 'activerecord-session_store'
 gem 'awesome_nested_fields'


### PR DESCRIPTION
This will set the version to 2.7 instead of 2.6 when deploying to Dokku and Heroku