### PR TITLE
Remove Age from Rails Admin so the user page loads

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -539,7 +539,6 @@ RailsAdmin.config do |config|
       field :email
       field :affiliation
       field :year_in_school.to_s
-      field :age
       field :area_of_study
       field :location
       field :personal_email
@@ -562,7 +561,6 @@ RailsAdmin.config do |config|
     list do
       field :full_name
       field :email
-      field :age
       field :current_sign_in_at
       field :sign_in_count
       field :interested_in_employment


### PR DESCRIPTION
This is a final cleanup from the previous https://github.com/mitre-cyber-academy/ctf-scoreboard/pull/755 PR.