### PR TITLE
Fix incorrectly named reset password translations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -409,8 +409,8 @@ en:
         Someone has requested a link to change your password, and you can do
         this through the link below.
       change_password_link: Change my password
-      change_password_line_2: 'If you did not request this, please ignore this email.'
-      change_password_line_3: >-
+      reset_password_line_2: 'If you did not request this, please ignore this email.'
+      reset_password_line_3: >-
         Your password will not change until you access the link above and create
         a new one.
     confirmation:


### PR DESCRIPTION
This was causing missing text on the reset password screen
