### PR TITLE
Mergify deprecated options update

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -12,7 +12,6 @@ pull_request_rules:
       - check-success=Build
     actions:
         queue:
-          method: merge
           name: default
           method: squash
   - name: automatic merge for updates when CI passes
@@ -23,7 +22,6 @@ pull_request_rules:
       - check-success=Build
     actions:
         queue:
-          method: merge
           name: default
           method: squash
   - name: delete head branch after merge

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,21 +1,30 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=Build
+
 pull_request_rules:
   - name: automatic merge for master when reviewed and CI passes
     conditions:
       - "#approved-reviews-by>=1"
       - base=master
       - label=ready-to-merge
+      - check-success=Build
     actions:
-        merge:
-          strict: true
+        queue:
+          method: merge
+          name: default
           method: squash
   - name: automatic merge for updates when CI passes
     conditions:
       - "#approved-reviews-by>=1"
       - base=master
       - label=dependencies
+      - check-success=Build
     actions:
-        merge:
-          strict: true
+        queue:
+          method: merge
+          name: default
           method: squash
   - name: delete head branch after merge
     conditions:


### PR DESCRIPTION
Merge: strict: true has been deprecated in Mergify and cannot be used any longer as of January. This uses a new way of performing automatic merges using a queue